### PR TITLE
Make random_string generate secure random strings.

### DIFF
--- a/peeps/functions.sql
+++ b/peeps/functions.sql
@@ -6,6 +6,7 @@
 -- pgcrypto for people.hashpass
 CREATE OR REPLACE FUNCTION crypt(text, text) RETURNS text AS '$libdir/pgcrypto', 'pg_crypt' LANGUAGE c IMMUTABLE STRICT;
 CREATE OR REPLACE FUNCTION gen_salt(text, integer) RETURNS text AS '$libdir/pgcrypto', 'pg_gen_salt_rounds' LANGUAGE c STRICT;
+CREATE OR REPLACE FUNCTION gen_random_bytes(integer) RETURNS bytea AS '$libdir/pgcrypto', 'pg_random_bytes' LANGUAGE c STRICT;
 
 
 -- used by other functions, below, for any random strings needed
@@ -14,9 +15,15 @@ DECLARE
 	chars text[] := '{0,1,2,3,4,5,6,7,8,9,A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z}';
 	result text := '';
 	i integer := 0;
+	rand bytea;
 BEGIN
-	FOR i IN 1..length LOOP
-		result := result || chars[1+random()*(array_length(chars, 1)-1)];
+	-- Generate secure random bytes and convert them to a string of chars.
+	-- Since our charset contains 62 characters, we will have a small
+	-- modulo bias, which is acceptable for our uses.
+	rand := gen_random_bytes(length);
+	FOR i IN 0..length-1 LOOP
+		result := result || chars[1 + (get_byte(rand, i) % array_length(chars, 1))];
+		-- note: rand indexing is zero-based, chars is 1-based.
 	END LOOP;
 	RETURN result;
 END;


### PR DESCRIPTION
PG's random() function is not suitable for cryptographic purposes,
such as generating unique and unpredictable authentication tokens or
passwords -- its entropy is limited to 48 bits and may be predictable.

This commit makes random_string() get random bytes from Pgcrypto's
gen_random_bytes(). Since our charset (A-z,0-9) contains 62 characters,
we will have a small modulo bias, which is acceptable for our uses.